### PR TITLE
refactor: if a hex string and 33 bytes, support it as a b64 format an…

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -230,6 +230,10 @@ func (s *S5Protocol) ValidIdentifier(identifier string) bool {
 		return true
 	}
 
+	if err == nil && len(ret) == 33 {
+		identifier = base64.RawURLEncoding.EncodeToString(ret)
+	}
+
 	ret, err = base64.RawURLEncoding.DecodeString(identifier)
 
 	if err == nil && len(ret) == 33 {


### PR DESCRIPTION
…d encode it so we can no-decode it